### PR TITLE
Fixed build bug when using explicit ahead template specification for …

### DIFF
--- a/examples/99_debugger/99_debugger.cpp
+++ b/examples/99_debugger/99_debugger.cpp
@@ -1,5 +1,9 @@
 #include "posit.h"
 
+namespace posit {
+template class Posit<int32_t, 32, 2, uint32_t, PositSpec::WithNan>;
+}
+
 float convert32(const float x) {
   posit::Posit<int32_t, 32, 2, uint32_t, posit::PositSpec::WithNan> y(x);
   const int32_t z =  *(int32_t*)&y;

--- a/include/posit.h
+++ b/include/posit.h
@@ -576,12 +576,12 @@ namespace posit
 		constexpr operator float() const { return to_backend(); }
 		constexpr operator double() const { return to_backend(); }
 		
-		constexpr operator short int() const { return to_backend();}
+		constexpr operator short int() const { return (int)to_backend();}
 		constexpr operator int() const { return to_backend(); }
 		constexpr operator long() const { return to_backend(); }
 		constexpr operator long long int() const { return to_backend();}		
 
-		constexpr operator short unsigned int() const { return to_backend();}
+		constexpr operator short unsigned int() const { return (unsigned int)to_backend();}
 		constexpr operator unsigned int() const { return to_backend();}
 		constexpr operator long unsigned int() const { return to_backend();}		
 		constexpr operator long long unsigned int() const { return to_backend();}		

--- a/tests/test_init.cpp
+++ b/tests/test_init.cpp
@@ -1,6 +1,7 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 #include <posit.h>
+#include <iostream>
 
 TEST_CASE("Initialize with deep initalization", "[short]") {
   using P = posit::Posit<int16_t, 16, 2, uint32_t, posit::PositSpec::WithInfs>;
@@ -20,3 +21,17 @@ TEST_CASE("Initialize with integer conversion", "[short]") {
   REQUIRE(a.v == (1<<14));
 }
 
+
+TEST_CASE("Initialize with big integers","[short]") {
+  uint64_t bigNum = uint64_t(INT32_MAX)*2;
+  posit::Posit<int32_t, 32, 2, uint32_t, posit::PositSpec::WithNan> x(bigNum);
+  REQUIRE(x.v == 2143289344);
+
+  uint32_t bigNum32 = uint32_t(INT16_MAX)*2;
+  posit::Posit<int16_t, 16, 2, uint16_t, posit::PositSpec::WithNan> y(bigNum),z(bigNum32);
+  REQUIRE(y.v == 32704);
+  REQUIRE(z.v == 31744);
+
+  posit::Posit<int8_t, 8, 2, uint16_t, posit::PositSpec::WithNan> w(bigNum);
+  REQUIRE(w.v == 127);
+}


### PR DESCRIPTION
…posit for short/unsigned operators